### PR TITLE
change current working directory before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc --build",
     "watch": "tsc --build --watch",
-    "postinstall": "npm run build"
+    "postinstall": "cd node_modules/docusaurus-plugin-simple-analytics && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Fix for Post-installation Script Failure in Issue #4** 

Hello,

We're proud users of Simple Analytics at [2bttns](https://www.2bttns.com), so I'd love to resolve this bug as we prepare to launch our MVP.

This is more of a band-aid than a long-term solution, and it'd be great to figure out why `tsc --build` isn't running in the right context. But for now, this should help get things moving again.

I'd really appreciate it if you could give this a test. I can't fully test this with my project app unless it's installing this as a dependency via npm and seeing if it actually works.

**Bug**
I've been struggling with a bug that pops up when installing `docusaurus-plugin-simple-analytics` as a dependency in another project. The `postinstall` script tries to run `tsc --build` and throws an error because it can't find the `tsconfig.json` file, even though it's right there in the repo (credit to @adriaanvanrossum for that find).

Here's the error message I'm seeing:

```
error TS5083: Cannot read file '/Documents/Development/Projects/2bttns-docs/node_modules/docusaurus-plugin-simple-analytics/tsconfig.json'
```

I've done some digging and considered a few possible causes:

1. Incorrect Node.js or npm version
2. Permission issues
3. Incompatible architecture (M1 Pro)
4. Corrupted npm cache
5. Issues with the `postinstall` script

I've ruled out the first four, so it looks like the `postinstall` script is the likely culprit. Here's what it looks like in the `package.json`:

```json
"scripts": {
  "postinstall": "npm run build"
}
```

The `build` script runs `tsc --build`, which should compile the TypeScript files using the `tsconfig.json` file. But when the package is installed into another project, it seems like `tsc --build` is running in the root directory of the host project, not the `node_modules/docusaurus-plugin-simple-analytics` directory. That's probably why it can't find the `tsconfig.json` file.

So, I've tweaked the `postinstall` script to change the current working directory before running the `build` script:

```json
"scripts": {
  "postinstall": "cd node_modules/docusaurus-plugin-simple-analytics && npm run build"
}
```

This should make sure `tsc --build` runs in the right place and can find the `tsconfig.json` file.

Thanks for your help!
